### PR TITLE
Fix program crash when switching accounts due to empty unhandled WS message

### DIFF
--- a/discover_overlay/discord_connector.py
+++ b/discover_overlay/discord_connector.py
@@ -760,6 +760,8 @@ class DiscordConnector:
             except websocket.WebSocketConnectionClosedException:
                 self.on_close()
                 return True
+            except json.decoder.JSONDecodeError:
+                return True
         return True
 
     def start_listening_text(self, channel):


### PR DESCRIPTION
Previously, the program would crash when attempting to switch accounts because an empty WS message was not being handled properly.

As long as it is handled, the previously implemented retry mechanism will handle account switching well